### PR TITLE
fix deserialize throwing error on empty content

### DIFF
--- a/lektor/admin/static/js/widgets/tagsWidget.jsx
+++ b/lektor/admin/static/js/widgets/tagsWidget.jsx
@@ -54,9 +54,13 @@ class TagsWidget extends React.Component {
 }
 
 TagsWidget.deserializeValue = value => {
-  const deserialized = JSON.parse(value)
-  if (!Array.isArray(deserialized)) return []
-  return transformTags(deserialized)
+  try {
+    const deserialized = JSON.parse(value)
+    if (!Array.isArray(deserialized)) return []
+    return transformTags(deserialized)
+  } catch (e) {
+    return []
+  }
 }
 TagsWidget.serializeValue = value => {
   const serialized = JSON.stringify(value)


### PR DESCRIPTION
the tags deserialize widget had a bug where given empty content (or any non-JSON content), it would throw an error, causing the page to crash

as the fields are all initialised to empty on creation of a new page, this results in not being able to create a new page that uses a tags widget

this PR fixes this