### PR TITLE
remove primary field on new child page view

### DIFF
--- a/lektor/admin/static/js/views/AddChildPage.jsx
+++ b/lektor/admin/static/js/views/AddChildPage.jsx
@@ -105,7 +105,7 @@ class AddChildPage extends RecordComponent {
     if (!this.state.newChildInfo.implied_model) {
       data['_model'] = this.state.selectedModel
     }
-    const primaryField = this.getPrimaryField()
+    const primaryField = false//this.getPrimaryField()
     if (primaryField) {
       data[primaryField.name] = this.state.primary
     }
@@ -171,7 +171,7 @@ class AddChildPage extends RecordComponent {
       )
     }
 
-    const primaryField = this.getPrimaryField()
+    const primaryField = false//this.getPrimaryField()
     if (primaryField) {
       addField('primary', primaryField)
     }


### PR DESCRIPTION
- removes the primary field on the AddChildPage view

Currently, the primary field is the first field of the model. This isn't great as the ordering of the model creates the ordering of the fields in the edit page, so the field that you want as the primary field isn't always going to the the first one.

There's also the question of why we even have a primary field? What is it for? Why are we allowing the user to populate a single field in the create subpage view?

Therefore this PR removes this field from that view.